### PR TITLE
Add language select shortcuts that are more comfortable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@
 <br>
 <br>
 
-## < Version: v0.203 >
+## < Version: v0.204>
 
 + last update
-    - Code: 2023-01-11
-    - Manual(README): 2023-01-11
+    - Code: 2023-01-25
+    - Manual(README): 2023-01-25
 
 <br>
 <br>
@@ -56,9 +56,19 @@
 
 
 * Input source changer:
-    * Change next input source: ctrl + space
-    * Select Korean: ctrl + opt + cmd + K
-    * Select English: ctrl + opt + cmd + J
+    * Toggle input source: 
+      * ctrl + space
+    * Select language directly 1:
+      * ctrl + opt + cmd + K (Korean)
+      * ctrl + opt + cmd + J (English)
+    * Select language directly 2 (comfortable)
+      * ctrl + shift + K (Korean)
+      * ctrl + shift + J (English)
+>* Note - It is so comfortable to use this way:
+>  * Left ctrl -> Left pinky finger
+>  * Right shift -> Right pinky finger 
+>  * K or J (Korean or English) -> Right index finger
+
 
 * Locate mouse cursor to other monitors:
     * shortcuts:

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
 
 
 * Input source changer:
-    * Toggle input source: 
+    * Toggle input source:
       * ctrl + space
     * Select language directly 1:
       * ctrl + opt + cmd + K (Korean)
@@ -65,9 +65,9 @@
       * ctrl + shift + K (Korean)
       * ctrl + shift + J (English)
 >* Note - It is so comfortable to use this way:
->  * Left ctrl -> Left pinky finger
->  * Right shift -> Right pinky finger 
->  * K or J (Korean or English) -> Right index finger
+>   * Left ctrl -> Left pinky finger
+>   * Right shift -> Right pinky finger
+>   * K or J (Korean or English) -> Right index finger
 
 
 * Locate mouse cursor to other monitors:

--- a/init.lua
+++ b/init.lua
@@ -143,7 +143,7 @@ do
     end
     hs.hotkey.bind({ 'ctrl' }, 'space', changeInput)
 
-    -- Select input source directly
+    -- Select input source directly (1)
     -- Korean : ctrl + option + cmd + K
     hs.hotkey.bind({ 'ctrl', 'option', 'cmd' }, 'K', function()
         hs.keycodes.currentSourceID(inputSource.korean)
@@ -151,6 +151,25 @@ do
     end)
     -- English : ctrl + option + cmd + J
     hs.hotkey.bind({ 'ctrl', 'option', 'cmd' }, 'J', function()
+        hs.keycodes.currentSourceID(inputSource.english)
+        hs.alert.show("English", 0.4)
+    end)
+
+
+    --[[
+        * More comfortable way to select input source directly
+            Left ctrl -> Left pinky finger
+            Right shift -> Right pinky finger
+            K or J (Korean or English) -> Right index finger
+    ]]--
+    -- Select input source directly (2)
+    -- Korean : ctrl + shift + K
+    hs.hotkey.bind({ 'ctrl', 'shift' }, 'K', function()
+        hs.keycodes.currentSourceID(inputSource.korean)
+        hs.alert.show("한국어", 0.4)
+    end)
+    -- English : ctrl + shift + J
+    hs.hotkey.bind({ 'ctrl', 'shift' }, 'J', function()
         hs.keycodes.currentSourceID(inputSource.english)
         hs.alert.show("English", 0.4)
     end)


### PR DESCRIPTION
Add language select shortcuts that are more comfortable

    * Add shortcut to Select input source directly
        Shortcut:
            ctrl + shift + K (Korean)
            ctrl + shift + J (English)

    * It is so comfortable to use this way:
        Left ctrl -> Left pinky finger
        Right shift -> Right pinky finger
        K or J (Korean or English) -> Right index finger