### PR TITLE
Feat > Add new shortcut for select input source

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@
 <br>
 <br>
 
-## < Version: v0.206a>
+## < Version: v0.206b>
 
 + last update
-    - Code: 2023-02-17
-    - Manual(README): 2023-02-17
+    - Code: 2023-02-18
+    - Manual(README): 2023-02-18
 
 <br>
 <br>
@@ -63,11 +63,11 @@
       * ctrl + opt + cmd + J (English)
     * Select language directly 2 (comfortable)
       * ctrl + shift + K (Korean)
-      * ctrl + shift + J (English)
+      * ctrl + shift + J or L(English)
 >* Note - It is so comfortable to use this way:
 >   * Left ctrl -> Left pinky finger
 >   * Right shift -> Right pinky finger
->   * K or J (Korean or English) -> Right index finger
+>   * K(korean) / J or L (English) -> Right index finger
 
 
 * Locate mouse cursor to other monitors:

--- a/init.lua
+++ b/init.lua
@@ -160,7 +160,7 @@ do
         * More comfortable way to select input source directly
             Left ctrl -> Left pinky finger
             Right shift -> Right pinky finger
-            K or J (Korean or English) -> Right index finger
+            K(korean) / J or L (English) -> Right index finger
     ]]--
     -- Select input source directly (2)
     -- Korean : ctrl + shift + K
@@ -170,6 +170,11 @@ do
     end)
     -- English : ctrl + shift + J
     hs.hotkey.bind({ 'ctrl', 'shift' }, 'J', function()
+        hs.keycodes.currentSourceID(inputSource.english)
+        hs.alert.show("English", 0.4)
+    end)
+    -- English : ctrl + shift + L
+    hs.hotkey.bind({ 'ctrl', 'shift' }, 'L', function()
         hs.keycodes.currentSourceID(inputSource.english)
         hs.alert.show("English", 0.4)
     end)


### PR DESCRIPTION
    It is just add one more shortcut key
    On Select input source directly (2) feature

    Add new shortcut key: < ctrl + shift + L >
        Change input source to English
            It is more comfortable than previous shortcut < ctrl + shift + J >
            J is too far from right shift key

        Previous shortcut key
            < ctrl + shift + J > to Eng
            < ctrl + shift + K > to Kor
            Are still working. not deleted

README > Update README.md
    Update the version and last update date
        version: v0.206a -> v0.206b
        Code & Manual date: 2022-02-17 -> 2022-02-18