### PR TITLE
Chrome control without focusing 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@
 <br>
 <br>
 
-## < Version: v0.206a>
+## < Version: v0.21>
 
 + last update
-    - Code: 2023-02-17
-    - Manual(README): 2023-02-17
+    - Code: 2023-03-19
+    - Manual(README): 2023-03-19
 
 <br>
 <br>
@@ -119,6 +119,33 @@
 
 ### Time checker
 * Show the current time on the screen: ctrl + opt + cmd + T
+
+
+### Google Chrome control without focusing
+* Tab control
+  * Move to left tab: ctrl + opt + [
+  * Move to right tab: ctrl + opt + ]
+* Media control
+  * Play/Pause: ctrl + opt + J or K
+  * Backward: ctrl + opt + H
+  * Forward: ctrl + opt + L
+> With these shortcuts,<br>
+> Control media playing in Chrome<br> 
+> while maintaining the activated window such as IDE
+
+> How it works ? -> When shortcut key is pressed, the following steps are executed:
+> 1. Activate Chrome window
+> 2. Simulate the key press event
+>    - Ctrl + Option + {key}
+>      - H: Left arrow
+>      - L: Right arrow
+>      - J or K: Space bar
+>      - [ or ]: cmd + opt + left or right arrow (Chrome default shortcut to move tab)
+> 3. Activate the previous window
+> <br>
+> 
+> Since this feature simulates the key press event,<br>
+> the tap that need to control media should be activated in Chrome
 
 
 <br>

--- a/init.lua
+++ b/init.lua
@@ -509,54 +509,36 @@ do
 
 
     -- Function to simulate key press
-    function simulateKeyPress(key)
-        hs.eventtap.keyStroke({}, key)
+    function simulateKeyPress(keys)
+        hs.eventtap.keyStroke({}, table.unpack({keys}))
     end
 
-
-    -- Function to play or pause Chrome video
-    function playPauseChrome()
+    -- Function to control Chrome by simulating key press
+    function controlChrome(keys)
         -- Focus Chrome
         focusChrome()
-        -- Simulate space bar key press to play/pause video
-        simulateKeyPress("space")
-        -- Focus the previously focused application
-        focusPrevious()
-    end
-
-    -- Function to seek backward in Chrome video
-    function backwardChrome()
-        -- Focus Chrome
-        focusChrome()
-        -- Simulate left arrow key press to seek backward
-        simulateKeyPress("left")
-        -- Focus the previously focused application
-        focusPrevious()
-    end
-
-    -- Function to seek forward in Chrome video
-    function forwardChrome()
-        -- Focus Chrome
-        focusChrome()
-        -- Simulate right arrow key press to seek forward
-        simulateKeyPress("right")
+        -- Simulate key press to control
+        simulateKeyPress(keys)
         -- Focus the previously focused application
         focusPrevious()
     end
 
 
     -- Keybindings for functions
+    -- Play/Pause
     hs.hotkey.bind({ 'ctrl', 'option' }, 'J', function()
-        playPauseChrome()
+        controlChrome("space")
     end)
     hs.hotkey.bind({ 'ctrl', 'option' }, 'K', function()
-        playPauseChrome()
+        controlChrome("space")
     end)
+    -- Backward
     hs.hotkey.bind({ 'ctrl', 'option' }, 'H', function()
-        backwardChrome()
+        controlChrome("left")
     end)
+    -- Forward
     hs.hotkey.bind({ 'ctrl', 'option' }, 'L', function()
-        forwardChrome()
+        controlChrome("right")
     end)
 end
 -- << CHROME MEDIA CONTROL END >> --

--- a/init.lua
+++ b/init.lua
@@ -203,8 +203,6 @@ end)
 
 
 -- << WINDOW CONTROL (CHANGE SIZE AND MOVE) >>
-
-
 do
     -- 🌟HALF SCREEN CONTROL🌟
 
@@ -461,3 +459,104 @@ do
     end)
 end
 -- << TIME CHECKER END >> --
+
+
+
+
+
+-- << CHROME MEDIA CONTROL START >> --
+do
+    -- Function to focus Chrome
+    function focusChrome()
+        --[[
+            How to get the bundle ID of chrome app for hs.application.get() parameter?
+                In terminal, run the following command:
+                    osascript -e 'id of app "Google Chrome"'
+                My result is: com.google.Chrome
+        ]]--
+        local chrome = hs.application.get("com.google.Chrome")
+        if chrome == nil then
+            return false
+        end
+
+        chrome:activate()
+        return true
+    end
+
+    -- Variable to store the bundle ID of the previously focused application
+    local previousAppID = nil
+
+    -- Function to focus the previously focused application
+    function focusPrevious()
+        if previousAppID == nil then
+            -- No previous app to focus
+            return
+        end
+        -- Launch or focus the previous app by its bundle ID
+        hs.application.launchOrFocusByBundleID(previousAppID)
+    end
+
+    -- Function to update the previous application variable
+    function updatePrevious()
+        local lastApp = hs.application.frontmostApplication()
+        if lastApp ~= nil then
+            previousAppID = lastApp:bundleID()
+        end
+    end
+
+    -- Bind updatePrevious to Hammerspoon's application watcher
+    hs.application.watcher.new(updatePrevious):start()
+
+
+    -- Function to simulate key press
+    function simulateKeyPress(key)
+        hs.eventtap.keyStroke({}, key)
+    end
+
+
+    -- Function to play or pause Chrome video
+    function playPauseChrome()
+        -- Focus Chrome
+        focusChrome()
+        -- Simulate space bar key press to play/pause video
+        simulateKeyPress("space")
+        -- Focus the previously focused application
+        focusPrevious()
+    end
+
+    -- Function to seek backward in Chrome video
+    function backwardChrome()
+        -- Focus Chrome
+        focusChrome()
+        -- Simulate left arrow key press to seek backward
+        simulateKeyPress("left")
+        -- Focus the previously focused application
+        focusPrevious()
+    end
+
+    -- Function to seek forward in Chrome video
+    function forwardChrome()
+        -- Focus Chrome
+        focusChrome()
+        -- Simulate right arrow key press to seek forward
+        simulateKeyPress("right")
+        -- Focus the previously focused application
+        focusPrevious()
+    end
+
+
+    -- Keybindings for functions
+    hs.hotkey.bind({ 'ctrl', 'option' }, 'J', function()
+        playPauseChrome()
+    end)
+    hs.hotkey.bind({ 'ctrl', 'option' }, 'K', function()
+        playPauseChrome()
+    end)
+    hs.hotkey.bind({ 'ctrl', 'option' }, 'H', function()
+        backwardChrome()
+    end)
+    hs.hotkey.bind({ 'ctrl', 'option' }, 'L', function()
+        forwardChrome()
+    end)
+end
+-- << CHROME MEDIA CONTROL END >> --

--- a/init.lua
+++ b/init.lua
@@ -509,36 +509,58 @@ do
 
 
     -- Function to simulate key press
-    function simulateKeyPress(keys)
-        hs.eventtap.keyStroke({}, table.unpack({keys}))
+    function simulateKeyPress(keys, modifiers)
+        -- If modifiers is not provided, set it to empty table
+        if modifiers == nil then
+            modifiers = {}
+        end
+        -- CAUSATION --
+        -- modifiers should be a table
+        -- keys should be a table
+        hs.eventtap.keyStroke(modifiers, table.unpack(keys))
     end
 
     -- Function to control Chrome by simulating key press
-    function controlChrome(keys)
+    function controlChrome(keys, modifiers)
+
         -- Focus Chrome
         focusChrome()
         -- Simulate key press to control
-        simulateKeyPress(keys)
+        simulateKeyPress(keys, modifiers)
         -- Focus the previously focused application
         focusPrevious()
     end
 
 
-    -- Keybindings for functions
-    -- Play/Pause
+
+    -- Keybindings for controlChrome function
+
+    -- CAUSATION --
+    -- --> argument keys should be a table
+    -- --> argument modifiers should be a table or nil
+
+    -- Tab control: Move to the left tab
+    hs.hotkey.bind({ 'ctrl', 'option' }, '[', function()
+        controlChrome({ "left" }, { 'option', 'cmd' })
+    end)
+    -- Tab control: Move to the right tab
+    hs.hotkey.bind({ 'ctrl', 'option' }, ']', function()
+        controlChrome({ "right" }, { 'option', 'cmd' })
+    end)
+    -- Media: Play/Pause
     hs.hotkey.bind({ 'ctrl', 'option' }, 'J', function()
-        controlChrome("space")
+        controlChrome({ "space" })
     end)
     hs.hotkey.bind({ 'ctrl', 'option' }, 'K', function()
-        controlChrome("space")
+        controlChrome({ "space" })
     end)
-    -- Backward
+    -- Media: Backward
     hs.hotkey.bind({ 'ctrl', 'option' }, 'H', function()
-        controlChrome("left")
+        controlChrome({ "left" })
     end)
-    -- Forward
+    -- Media: Forward
     hs.hotkey.bind({ 'ctrl', 'option' }, 'L', function()
-        controlChrome("right")
+        controlChrome({ "right" })
     end)
 end
 -- << CHROME MEDIA CONTROL END >> --


### PR DESCRIPTION
< New Shortcut >
    Shortcuts for media control in Chrome
            Ctrl + Option + J or K : Play/Pause
            Ctrl + Option + H : Backward
            Ctrl + Option + L : Forward

    Shortcuts for tab control in Chrome
            Ctrl + Option + [ or ] : move left/right tab


< Why I make this feature >
    I make this feature for watching development lecture video in Chrome

    Previously, I had to focus on the Chrome window to control media
    then switch back to the IDE window
    It is so uncomfortable and required the use of mouse

    With this feature,
    Chrome could be controlled
    while maintaining the activated window such as IDE

    This feature works any media in Chrome including YouTube, Netflix, Udemy, and more

    Mapping the shortcut key to H/J/K/L for intuitive control:
        Left arrow: Backward
        Right arrow: Forward
        Up or Down arrow: Play/Pause


    And add tab control shortcuts:
        Ctrl + Option + [ or ] : move left/right tab


< How it works >
    When shortcut key is pressed, the following steps are executed:
        1. Activate Chrome window
        2. Simulate the key press event
            - Ctrl + Option + H/J/K/L
                - H: Left arrow
                - L: Right arrow
                - J or K: Space bar
            - Ctrl + Option + [ or ]
                - [ or ]: opt + cmd + left/right arrow (These are Chrome default shortcut to move tab)
        3. Activate the previous window

    Consequentially, working window is going to be not changed although Chrome is controlled

    Since this feature simulates the key press event,
    the tap that need to control media should be activated in Chrome

    This is why the tab control shortcuts are included
    To move to the media tab before controlling media - Play/Pause, Backward, Forward